### PR TITLE
refactor: use snafu instead of thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ embassy-executor = { version = "0.2.0", features = [
   "nightly",
 ], optional = true }
 embassy-time = { version = "0.1.2", optional = true }
-thiserror-no-std = "2.0.2"
+snafu = { version = "0.7.5", default-features = false }
 
 [dev-dependencies]
 embassy-futures = "0.1.0"

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -42,7 +42,7 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 use embassy_executor::{SpawnError, SpawnToken, Spawner as EmbassySpawner};
-use thiserror_no_std::Error;
+use snafu::prelude::*;
 
 /// The trait to replace the [`embassy_executor::Spawner`] in code to allow the [`MockSpawner`] to
 /// be used in its place for tests.
@@ -61,10 +61,10 @@ impl Spawner for EmbassySpawner {
 }
 
 /// The errors that are reported by [`MockSpawner`].
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Snafu, PartialEq)]
 pub enum MockSpawnerError {
     /// The [`MockSpawner::spawn()`] method was called the wrong number of times.
-    #[error("expected to spawn {expected} task(s), actually spawned {actual}")]
+    #[snafu(display("expected to spawn {expected} task(s), actually spawned {actual}"))]
     WrongNumberOfTasks {
         /// The expected number of calls to [`MockSpawner::spawn()`].
         expected: usize,

--- a/src/time/ticker.rs
+++ b/src/time/ticker.rs
@@ -46,7 +46,7 @@ use core::{
     task::Poll,
 };
 use embassy_time::{Duration, Ticker as EmbassyTicker};
-use thiserror_no_std::Error;
+use snafu::prelude::*;
 
 /// The trait to replace the [`embassy_time::Ticker`] in code to allow the [`MockTicker`] to
 /// be used in its place for tests.
@@ -71,10 +71,10 @@ impl Ticker for EmbassyTicker {
 }
 
 /// The errors that are reported by [`MockTicker`].
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Snafu, PartialEq)]
 pub enum MockTickerError {
     /// The [`MockTicker::next()`] method was called the wrong number of times.
-    #[error("expected to call next {expected} time(s), actually called {actual}")]
+    #[snafu(display("expected to call next {expected} time(s), actually called {actual}"))]
     WrongNumberOfTicks {
         /// The expected number of calls to [`MockTicker::next()`].
         expected: usize,


### PR DESCRIPTION
thiserror-no-std is an unofficial fork of this error and not widely used whereas snafu officially supports no-std projects and adds some extra features.