### PR TITLE
chore(codecov): set check for coverage delta

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%


### PR DESCRIPTION
* Setting the target to auto sets the base branch coverage value as the target.
* Setting the threshold to 0% means no change from the target.