### PR TITLE
chore(cliff): remove newline after version

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -34,7 +34,7 @@ body = """
             {% endif -%}
         {% endif -%}
     {% endfor -%}
-{% endfor %}\n
+{% endfor %}
 """
 # remove the leading and trailing whitespace from the template
 trim = true


### PR DESCRIPTION
release-plz seems to add a newline already which gives two newlines between versions which goes against markdown lints.